### PR TITLE
XOR function: indexed with module instead of a newvariable

### DIFF
--- a/hack.cpp
+++ b/hack.cpp
@@ -83,15 +83,10 @@ char s_key[] = "mysupersecretkey";
 
 // XOR decrypt
 void XOR(char * data, size_t data_len, char * key, size_t key_len) {
-  int j;
-  j = 0;
   for (int i = 0; i < data_len; i++) {
-    if (j == key_len - 1) j = 0;
-    data[i] = data[i] ^ key[j];
-    j++;
+    data[i] = data[i] ^ key[i % key_len];
   }
 }
-
 
 int main(int argc, char* argv[]) {
   XOR((char *) s_dll, sizeof(s_dll), s_key, sizeof(s_key));


### PR DESCRIPTION
Just a little change, a simplified version of your loop without the second counter.

---

I can't test right now because I'm not under Windows, but I think you might change also this:

```C
int cmpUnicodeStr(WCHAR substr[], WCHAR mystr[]) {
  _wcslwr_s(substr, MAX_PATH);
  _wcslwr_s(mystr, MAX_PATH);

  int result = 0;
  if (StrStrW(mystr, substr) != NULL) {
    result = 1;
  }

  return result;
}
```

Into this:

```C
int cmpUnicodeStr(WCHAR substr[], WCHAR mystr[]) {
  _wcslwr_s(substr, MAX_PATH);
  _wcslwr_s(mystr, MAX_PATH);

  return StrStrW(mystr, substr) != NULL;
}
```

and avoid the if statement.